### PR TITLE
add active datastax databases serviced via GCP

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -1,15 +1,14 @@
 ---
-sourceId: managed:template
+sourceId: managed:datastax
 integrationDefinitionId: '${integration_definition_id}'
-questions: []
-  # - id: integration-question-template-replace-me
-  #   title: What kinds of questions will this integration support?
-  #   description:
-  #     TODO Every integration should contribute questions! Please be carefule
-  #     to replace this before deploying the integration to JupiterOne.
-  #   queries:
-  #     - name: good
-  #       query: |
-  #         find * with _integrationDefinitionId = '${integration_definition_id}'
-  #   tags:
-  #     - template
+questions: 
+- id: managed-question-datastax-active-databases-with-available-actions-are-serviced-via-GCP.
+  title: Which Datastax active databases with available actions are serviced via the Google Cloud Platform?
+  description: Returns a list of DataStax active databases with available actions in your GCP cloud.
+  queries:
+      - name: informative
+        query: |
+          FIND * WITH _integrationType ~='stax' AND  _class != "AccessRole" AND active = true AND observedStatus ~= 'ACTIVE' AND info.cloudProvider ~= "GCP" 
+  tags:
+      - datastax
+      - database


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
